### PR TITLE
Fix build permissions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,8 +86,14 @@ impl Build {
         cp_r(&source_dir, &build_dir);
 
         // Copy release version file
+        let relver = build_dir.join(".relver");
         #[rustfmt::skip]
-        fs::copy(manifest_dir.join("luajit_relver.txt"), build_dir.join(".relver")).unwrap();
+        fs::copy(manifest_dir.join("luajit_relver.txt"), &relver).unwrap();
+
+        // Fix permissions for certain build situations
+        let mut perms = fs::metadata(&relver).unwrap().permissions();
+        perms.set_readonly(false);
+        fs::set_permissions(relver, perms).unwrap();
 
         let mut cc = cc::Build::new();
         cc.warnings(false);


### PR DESCRIPTION
On some linux systems, if the luajit folder is read-only, when `luajit_relver.txt` gets copied, it will still have read-only permissions and then fail when opened later. This causes CI failures in certain Nix configurations. The fix is to simply ensure the file isn't read-only after copying. I only made this change to the linux build, but it is at least theoretically possible that it could happen on the windows build as well, though I don't have any examples.

[Example of failing CI](https://github.com/Fundament-Institute/feather-ui/actions/runs/17344201434/job/49242045304)

[Example of successful CI with patch applied](https://github.com/Fundament-Institute/feather-ui/actions/runs/17353912717/job/49264127251)